### PR TITLE
Lighten --production installs, version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eol",
   "description": "Newline character converter",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "homepage": "https://github.com/ryanve/eol",
   "license": "MIT",
   "author": "Ryan Van Etten",
@@ -40,5 +40,8 @@
     "supernew": true,
     "undef": true,
     "unused": true
-  }
+  },
+  "files": [
+    "eol.js"
+  ]
 }


### PR DESCRIPTION
Via `npm install --production`, only eol.js and default npm files (readme.md, package.json) will be installed.

Please `npm publish` if/when accepting these changes.
