### PR TITLE
Add Typescript type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,41 @@
+declare module eol {
+    /**
+     * Normalize line endings in text for the current operating system
+     * @return string with line endings normalized to \r\n or \n
+     */
+    export function auto(text: string): string;
+
+    /**
+     * Normalize line endings in text to CRLF (Windows, DOS)
+     * @return string with line endings normalized to \r\n
+     */
+    export function crlf(text: string): string;
+
+    /**
+     * Normalize line endings in text to LF (Unix, OS X)
+     * @return string with line endings normalized to \n
+     */
+    export function lf(text: string): string;
+
+    /**
+     * Normalize line endings in text to CR (Mac OS)
+     * @return string with line endings normalized to \r
+     */
+    export function cr(text: string): string;
+
+    /**
+     * Add linebreak before text
+     * @return string with linebreak added before text
+     */
+    export function before(text: string): string;
+
+    /**
+     * Add linebreak after text
+     * @return string with linebreak added after text
+     */
+    export function after(text: string): string;
+}
+
+declare module "eol" {
+    export = eol;
+}

--- a/package.json
+++ b/package.json
@@ -50,5 +50,7 @@
     "supernew": true,
     "undef": true,
     "unused": true
-  }
+  },
+  "types": "./index.d.ts",
+  "typings": "./index.d.ts"
 }


### PR DESCRIPTION
I've written some TypeScript type definitions for this project, and this PR will include them in the distribution and allow either [typings](https://github.com/typings/typings) or [@types in TypeScript 2.x](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html) to automatically pick them up.
