### PR TITLE
Add eol.split method

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,5 +35,9 @@ var eol = require('eol')
 - Add linebreak after <var>text</var>
 - <b>@return</b> string with linebreak added after text
 
+### `eol.split(text)`
+- Split <var>text</var> by newline
+- <b>@return</b> array of lines
+
 ## License
 MIT

--- a/eol.d.ts
+++ b/eol.d.ts
@@ -34,6 +34,12 @@ declare module eol {
    * @return string with linebreak added after text
    */
   export function after(text: string): string;
+
+  /**
+   * Split text by newline
+   * @return array of lines
+   */
+  export function split(text: string): Array<string>;
 }
 
 declare module "eol" {

--- a/eol.js
+++ b/eol.js
@@ -22,11 +22,16 @@
     }
   }
 
+  function split(text) {
+    return text.split(newline)
+  }
+
   api['lf'] = converts('\n')
   api['cr'] = converts('\r')
   api['crlf'] = converts('\r\n')
   api['auto'] = converts(linebreak)
   api['before'] = before
   api['after'] = after
+  api['split'] = split
   return api
 });

--- a/test.js
+++ b/test.js
@@ -23,6 +23,11 @@
   aok('lf repeat newlines intact', eol.lf('\n\n\r\r') === '\n\n\n\n')
   aok('cr repeat newlines intact', eol.cr('\n\n\r\r') === '\r\r\r\r')
   aok('crlf repeat newlines intact', eol.crlf('\r\n\r\n') === '\r\n\r\n')
+  aok('split return type', eol.split('0\n1\n2') instanceof Array)
+  aok('split lf', eol.split('0\n1\n2').join('') === '012')
+  aok('split cr', eol.split('0\r1\r2').join('') === '012')
+  aok('split crlf', eol.split('0\r\n1\r\n2').join('') === '012')
+  aok('split mixed', eol.split('0\r\n1\n2\r3\r\n4').join('') === '01234')
 
   aok.pass(meths, function(method, i) {
     var normalized = eol[method](sample)


### PR DESCRIPTION
New method for splitting text into array of lines. Going with `eol.split` as the name for now. Is this good or would a name like `eol.lines` make more sense?