### PR TITLE
Extend API to join Array arguments with EOL for convert functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,18 +14,22 @@ var eol = require('eol')
 ### `eol.auto(text)`
 - Normalize line endings in <var>text</var> for the current operating system
 - <b>@return</b> string with line endings normalized to `\r\n` or `\n`
+- If <var>text</var> is an array, join with `\r\n` or `\n`
 
 ### `eol.crlf(text)`
 - Normalize line endings in <var>text</var> to <b>CRLF</b> (Windows, DOS)
 - <b>@return</b> string with line endings normalized to `\r\n`
+- If <var>text</var> is an array, join with `\r\n`
 
 ### `eol.lf(text)`
 - Normalize line endings in <var>text</var> to <b>LF</b> (Unix, OS X)
 - <b>@return</b> string with line endings normalized to `\n`
+- If <var>text</var> is an array, join with `\n`
 
 ### `eol.cr(text)`
 - Normalize line endings in <var>text</var> to <b>CR</b> (Mac OS)
 - <b>@return</b> string with line endings normalized to `\r`
+- If <var>text</var> is an array, join with `\r`
 
 ### `eol.before(text)`
 - Add linebreak before <var>text</var>

--- a/eol.d.ts
+++ b/eol.d.ts
@@ -3,25 +3,25 @@ declare module eol {
    * Normalize line endings in text for the current operating system
    * @return string with line endings normalized to \r\n or \n
    */
-  export function auto(text: string): string;
+  export function auto(text: string|string[]): string;
 
   /**
    * Normalize line endings in text to CRLF (Windows, DOS)
    * @return string with line endings normalized to \r\n
    */
-  export function crlf(text: string): string;
+  export function crlf(text: string|string[]): string;
 
   /**
    * Normalize line endings in text to LF (Unix, OS X)
    * @return string with line endings normalized to \n
    */
-  export function lf(text: string): string;
+  export function lf(text: string|string[]): string;
 
   /**
    * Normalize line endings in text to CR (Mac OS)
    * @return string with line endings normalized to \r
    */
-  export function cr(text: string): string;
+  export function cr(text: string|string[]): string;
 
   /**
    * Add linebreak before text

--- a/eol.js
+++ b/eol.js
@@ -18,7 +18,12 @@
 
   function converts(to) {
     return function(text) {
-      return text.replace(newline, to)
+      if (Array.isArray(text)) {
+        return text.map(function(text) {
+          return text.replace(newline, to);
+        }).join(to);
+      }
+      return text.replace(newline, to);
     }
   }
 

--- a/eol.js
+++ b/eol.js
@@ -20,10 +20,10 @@
     return function(text) {
       if (Array.isArray(text)) {
         return text.map(function(text) {
-          return text.replace(newline, to);
-        }).join(to);
+          return text.replace(newline, to)
+        }).join(to)
       }
-      return text.replace(newline, to);
+      return text.replace(newline, to)
     }
   }
 

--- a/test.js
+++ b/test.js
@@ -31,7 +31,7 @@
   aok('joins strings by lf', eol.lf(['a','b','c']) === 'a\nb\nc')
   aok('joins strings by cr', eol.cr(['a','b','c']) === 'a\rb\rc')
   aok('joins strings by crlf', eol.crlf(['a','b','c']) === 'a\r\nb\r\nc')
-  aok('joins strings', eol.auto(['a','b','c']) === isWindows ? 'a\r\nb\r\nc' : 'a\nb\nc' )
+  aok('joins strings', eol.auto(['a','b','c']) === isWindows ? 'a\r\nb\r\nc' : 'a\nb\nc')
 
   aok.pass(meths, function(method, i) {
     var normalized = eol[method](sample)

--- a/test.js
+++ b/test.js
@@ -28,6 +28,10 @@
   aok('split cr', eol.split('0\r1\r2').join('') === '012')
   aok('split crlf', eol.split('0\r\n1\r\n2').join('') === '012')
   aok('split mixed', eol.split('0\r\n1\n2\r3\r\n4').join('') === '01234')
+  aok('joins strings by lf', eol.lf(['a','b','c']) === 'a\nb\nc')
+  aok('joins strings by cr', eol.cr(['a','b','c']) === 'a\rb\rc')
+  aok('joins strings by crlf', eol.crlf(['a','b','c']) === 'a\r\nb\r\nc')
+  aok('joins strings', eol.auto(['a','b','c']) === isWindows ? 'a\r\nb\r\nc' : 'a\nb\nc' )
 
   aok.pass(meths, function(method, i) {
     var normalized = eol[method](sample)


### PR DESCRIPTION
Hi @ryanve!  I like the simplicity of your API.  I have a need to do `join` operations for each type, and thought an elegant solution would be to extend your library to do this implicitly in the `auto`, `lf`, `crlf`, and `cr` functions when Array argument is passed in.

I like being able to say: `return eol.lf(lines);` instead of `return lines.join('\n');` if I'm already using your library.

Let me know if you like it too, and I won't need to fork on npm to use!

Cheers :)