### PR TITLE
Coerce the convert functions to strings as the convert value.

### DIFF
--- a/eol.js
+++ b/eol.js
@@ -17,9 +17,13 @@
   }
 
   function converts(to) {
-    return function(text) {
+    function convert(text) {
       return text.replace(newline, to)
     }
+    convert.toString = function() {
+      return to
+    }
+    return convert 
   }
 
   function split(text) {

--- a/test.js
+++ b/test.js
@@ -28,6 +28,10 @@
   aok('split cr', eol.split('0\r1\r2').join('') === '012')
   aok('split crlf', eol.split('0\r\n1\r\n2').join('') === '012')
   aok('split mixed', eol.split('0\r\n1\n2\r3\r\n4').join('') === '01234')
+  aok('lf function coerces to string', String(eol.lf) === '\n')
+  aok('crlf function coerces to string', String(eol.crlf) === '\r\n')
+  aok('cr function coerces to string', String(eol.cr) === '\r')
+  aok('auto function coerces to string', String(eol.auto) === isWindows ? '\r\n' : '\n')
 
   aok.pass(meths, function(method, i) {
     var normalized = eol[method](sample)


### PR DESCRIPTION
This allows statements such as the following:

```js
var text = lines.join(eol.lf)
var lines = text.split(eol.auto)
```

WDYT?