### PR TITLE
Document the string coercion sugar

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,5 +39,16 @@ var eol = require('eol')
 - Split <var>text</var> by newline
 - <b>@return</b> array of lines
 
+### Joining
+
+Coercing `eol.auto`|`eol.crlf`|`eol.lf`|`eol.cr` to string yields the appropriate character. This is useful for joining.
+
+```js
+String(eol.lf) // "\n"
+eol.split(text).join(eol.auto) // same as eol.auto(text)
+eol.split(text).filter(line => line).join(eol.auto) // text joined after removing empty lines
+eol.split(text).slice(-3).join(eol.auto) // last 3 lines joined
+```
+
 ## License
 MIT

--- a/test.js
+++ b/test.js
@@ -3,6 +3,10 @@
     return !!~str.indexOf(needle);
   }
 
+  function identity(v) {
+    return v
+  }
+
   var common = typeof module != 'undefined' && !!module.exports
   var aok = common ? require('aok') : root.aok
   var eol = common ? require('./') : root.eol
@@ -23,15 +27,17 @@
   aok('lf repeat newlines intact', eol.lf('\n\n\r\r') === '\n\n\n\n')
   aok('cr repeat newlines intact', eol.cr('\n\n\r\r') === '\r\r\r\r')
   aok('crlf repeat newlines intact', eol.crlf('\r\n\r\n') === '\r\n\r\n')
+  aok('lf function coerces to string', String(eol.lf) === '\n')
+  aok('crlf function coerces to string', String(eol.crlf) === '\r\n')
+  aok('cr function coerces to string', String(eol.cr) === '\r')
+  aok('auto function coerces to string', String(eol.auto) === isWindows ? '\r\n' : '\n')
   aok('split return type', eol.split('0\n1\n2') instanceof Array)
   aok('split lf', eol.split('0\n1\n2').join('') === '012')
   aok('split cr', eol.split('0\r1\r2').join('') === '012')
   aok('split crlf', eol.split('0\r\n1\r\n2').join('') === '012')
   aok('split mixed', eol.split('0\r\n1\n2\r3\r\n4').join('') === '01234')
-  aok('lf function coerces to string', String(eol.lf) === '\n')
-  aok('crlf function coerces to string', String(eol.crlf) === '\r\n')
-  aok('cr function coerces to string', String(eol.cr) === '\r')
-  aok('auto function coerces to string', String(eol.auto) === isWindows ? '\r\n' : '\n')
+  aok('split filter join', eol.split('A\n\nB').filter(identity).join(eol.lf) === 'A\nB')
+  aok('split slice join', eol.split('A\nB\nC\nD').slice(-2).join(eol.lf) === 'C\nD')
 
   aok.pass(meths, function(method, i) {
     var normalized = eol[method](sample)

--- a/test.js
+++ b/test.js
@@ -36,6 +36,7 @@
   aok('split cr', eol.split('0\r1\r2').join('') === '012')
   aok('split crlf', eol.split('0\r\n1\r\n2').join('') === '012')
   aok('split mixed', eol.split('0\r\n1\n2\r3\r\n4').join('') === '01234')
+  aok('split join', eol.split('0\n1\n\n2\n').join(eol.auto) === eol.auto('0\n1\n\n2\n'))
   aok('split filter join', eol.split('A\n\nB').filter(identity).join(eol.lf) === 'A\nB')
   aok('split slice join', eol.split('A\nB\nC\nD').slice(-2).join(eol.lf) === 'C\nD')
 


### PR DESCRIPTION
This documents the [recently added string coercion sugar](https://github.com/ryanve/eol/pull/11) and tests the examples.

```js
String(eol.lf) // "\n"
eol.split(text).join(eol.auto) // same as eol.auto(text)
eol.split(text).filter(line => line).join(eol.auto) // text joined after removing empty lines
eol.split(text).slice(-3).join(eol.auto) // last 3 lines joined
```